### PR TITLE
supporting optional additional attributes

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,7 @@ const StaticSiteJson = require('broccoli-static-site-json');
 const BroccoliMergeTrees = require('broccoli-merge-trees');
 
 const jsonTree = new StaticSiteJson(`content/ember/v2`, {
+  attributes: ['title', 'since', 'until'],
   collections: [{
     src: 'content/ember/v2',
     output: 'ember-v2.json',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-static-site-json": "^1.1.0",
+    "broccoli-static-site-json": "^1.2.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.16.2",
     "ember-cli-app-version": "^3.0.0",


### PR DESCRIPTION
- Bumped the version number of broccoli-static-site-json to 1.2.0 to support optional attributes, see
https://github.com/stonecircle/broccoli-static-site-json/pull/2
- Added additional attributes since, until